### PR TITLE
refactor: Update Overview page with grid layout and view mode support

### DIFF
--- a/src/components/Overview/ConnectionLines.tsx
+++ b/src/components/Overview/ConnectionLines.tsx
@@ -11,6 +11,7 @@ interface Connection {
   to: string;
   color?: string;
   strokeWidth?: number;
+  strokeDasharray?: string;
 }
 
 interface ConnectionLinesProps {
@@ -63,27 +64,20 @@ export const ConnectionLines: React.FC<ConnectionLinesProps> = ({
   const drawConnection = (connection: Connection) => {
     const fromPoint = connectionPoints.get(connection.from);
     const toPoint = connectionPoints.get(connection.to);
-    
+
     if (!fromPoint || !toPoint) return null;
 
-    const dx = toPoint.x - fromPoint.x;
-    const dy = toPoint.y - fromPoint.y;
-    const distance = Math.sqrt(dx * dx + dy * dy);
-    
-    // 베지어 곡선을 위한 제어점 계산
-    const controlPoint1X = fromPoint.x + dx * 0.3;
-    const controlPoint1Y = fromPoint.y;
-    const controlPoint2X = toPoint.x - dx * 0.3;
-    const controlPoint2Y = toPoint.y;
-
     return (
-      <path
+      <line
         key={`${connection.from}-${connection.to}`}
-        d={`M ${fromPoint.x} ${fromPoint.y} C ${controlPoint1X} ${controlPoint1Y}, ${controlPoint2X} ${controlPoint2Y}, ${toPoint.x} ${toPoint.y}`}
+        x1={fromPoint.x}
+        y1={fromPoint.y}
+        x2={toPoint.x}
+        y2={toPoint.y}
         stroke={connection.color || '#3b82f6'}
         strokeWidth={connection.strokeWidth || 2}
-        fill="none"
         strokeLinecap="round"
+        strokeDasharray={connection.strokeDasharray}
         className="transition-all duration-300"
       />
     );

--- a/src/components/Overview/MainCoreView.tsx
+++ b/src/components/Overview/MainCoreView.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef } from 'react';
-import { Camera, Wifi, Settings, ChevronDown } from 'lucide-react';
-import { ConnectionLines, ConnectionPoint } from './ConnectionLines';
+import { Camera, Wifi, Settings, ChevronDown, Cpu, Box, Monitor, AlertCircle } from 'lucide-react';
+import { useCameraStore } from '@/store/cameraStore';
 
 interface MainCoreViewProps {
   selectedDevices: {
@@ -10,11 +10,12 @@ interface MainCoreViewProps {
   onDeviceClick: (mipi: 'mipi0' | 'mipi1') => void;
 }
 
-export const MainCoreView: React.FC<MainCoreViewProps> = ({ 
-  selectedDevices, 
-  onDeviceClick 
+export const MainCoreView: React.FC<MainCoreViewProps> = ({
+  selectedDevices,
+  onDeviceClick
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const viewMode = useCameraStore(state => state.viewMode);
   const [mipi0Enabled, setMipi0Enabled] = useState(true);
   const [mipi1Enabled, setMipi1Enabled] = useState(false);
   const [ispSelections, setIspSelections] = useState({
@@ -26,12 +27,6 @@ export const MainCoreView: React.FC<MainCoreViewProps> = ({
 
   const deviceColors = ['bg-blue-500', 'bg-green-500', 'bg-red-500', 'bg-yellow-500'];
 
-  // 연결선 정의
-  const connections = [
-    { from: 'external-devices-mipi0', to: 'mipi0', color: '#3b82f6', strokeWidth: 3 },
-    { from: 'mipi0', to: 'camera-mux', color: '#8b5cf6', strokeWidth: 3 },
-    { from: 'camera-mux', to: 'svdw', color: '#eab308', strokeWidth: 3 },
-  ];
 
   const handleIspChange = (isp: string, value: string) => {
     setIspSelections(prev => ({
@@ -42,143 +37,228 @@ export const MainCoreView: React.FC<MainCoreViewProps> = ({
 
   return (
     <div className="w-full h-full">
-      {/* Main Core View Title */}
+      {/* System Overview Title */}
       <div className="text-center mb-8">
-        <h2 className="text-2xl font-bold text-gray-100 mb-2">Main Core View</h2>
-        <p className="text-gray-400">Primary camera processing path with ISP and SVDW</p>
+        <h2 className="text-2xl font-bold text-gray-100 mb-2">
+          {viewMode === 'unified' ? 'Unified View' : viewMode === 'main' ? 'Main Core View' : 'Sub Core View'}
+        </h2>
+        <p className="text-gray-400">
+          {viewMode === 'unified' ? 'Complete camera system overview' :
+           viewMode === 'main' ? 'Primary camera processing path' :
+           'Secondary camera processing path'}
+        </p>
       </div>
 
       {/* Diagram Container */}
-      <div ref={containerRef} className="relative w-full h-full min-h-[600px] bg-gray-800 rounded-lg p-8">
+      <div ref={containerRef} className="w-full bg-gray-800 rounded-lg p-6">
         
-        {/* External Devices - MIPI0 */}
-        <ConnectionPoint id="external-devices-mipi0" position="right">
-          <div className="absolute left-8 top-16">
-            <div 
-              className="bg-blue-600 text-white p-4 rounded-lg cursor-pointer hover:bg-blue-700 transition-colors"
-              onClick={() => onDeviceClick('mipi0')}
-            >
-            <div className="flex items-center gap-2 mb-2">
-              <Camera className="w-5 h-5" />
-              <span className="font-semibold">External Devices</span>
-            </div>
-            <div className="grid grid-cols-2 gap-2">
-              {deviceColors.map((color, index) => (
-                <div 
-                  key={index}
-                  className={`w-8 h-8 rounded ${color} ${
-                    selectedDevices.mipi0.includes(`device${index}`) 
-                      ? 'ring-2 ring-white' 
-                      : 'opacity-50'
-                  }`}
-                />
-              ))}
-            </div>
-            </div>
-          </div>
-        </ConnectionPoint>
+        {/* Main Grid Layout */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7 gap-4 relative">
 
-        {/* MIPI0 Block */}
-        <ConnectionPoint id="mipi0" position="right">
-          <div className="absolute left-48 top-16">
-            <div className="bg-purple-600 text-white p-4 rounded-lg w-32">
-            <div className="flex items-center justify-between mb-2">
-              <span className="font-semibold">MIPI0</span>
-              <input
-                type="checkbox"
-                checked={mipi0Enabled}
-                onChange={(e) => setMipi0Enabled(e.target.checked)}
-                className="w-4 h-4"
-              />
-            </div>
-            <div className="text-xs mb-2">I2C12</div>
-            <div className="space-y-1">
-              {['ISP0', 'ISP1', 'ISP2', 'ISP3'].map((isp, index) => (
-                <div key={isp} className="flex items-center gap-2">
-                  <div className="w-2 h-2 bg-white rounded-full"></div>
-                  <select
-                    value={ispSelections[`isp${index}` as keyof typeof ispSelections]}
-                    onChange={(e) => handleIspChange(`isp${index}` as keyof typeof ispSelections, e.target.value)}
-                    className="bg-purple-700 text-white text-xs px-1 py-0.5 rounded border-0"
-                  >
-                    <option value="ISP0">ISP0</option>
-                    <option value="ISP1">ISP1</option>
-                    <option value="ISP2">ISP2</option>
-                    <option value="ISP3">ISP3</option>
-                    <option value="Bypass">Bypass</option>
-                  </select>
+          {/* External Devices Column */}
+          <div className="flex flex-col">
+            <div className="text-gray-400 text-sm mb-2 text-center">External Devices</div>
+            <div className="space-y-3">
+              {/* External Device 1 - Show in unified and main */}
+              {(viewMode === 'unified' || viewMode === 'main') && (
+                <div
+                  className="bg-blue-600 text-white p-3 rounded-lg cursor-pointer hover:bg-blue-700 transition-colors"
+                  onClick={() => onDeviceClick('mipi0')}
+                >
+                  <div className="flex items-center gap-2 justify-center">
+                    <Camera className="w-4 h-4" />
+                    <span className="text-xs font-semibold">Device 1</span>
+                  </div>
                 </div>
-              ))}
-            </div>
+              )}
+
+              {/* External Device 2 - Show in unified and sub */}
+              {(viewMode === 'unified' || viewMode === 'sub') && (
+                <div
+                  className="bg-blue-600 text-white p-3 rounded-lg cursor-pointer hover:bg-blue-700 transition-colors"
+                  onClick={() => onDeviceClick('mipi1')}
+                >
+                  <div className="flex items-center gap-2 justify-center">
+                    <Camera className="w-4 h-4" />
+                    <span className="text-xs font-semibold">Device 2</span>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
-        </ConnectionPoint>
 
-        {/* IR Blocks */}
-        <div className="absolute left-80 top-24">
-          <div className="bg-orange-500 text-white p-2 rounded text-xs">IR0</div>
+          {/* MIPI Column */}
+          <div className="flex flex-col">
+            <div className="text-gray-400 text-sm mb-2 text-center">MIPI CSI</div>
+            <div className="space-y-3">
+              {/* MIPI0 Block - Show in unified and main */}
+              {(viewMode === 'unified' || viewMode === 'main') && (
+                <div className="bg-purple-600 text-white p-3 rounded-lg">
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-xs font-semibold">MIPI0</span>
+                    <input
+                      type="checkbox"
+                      checked={mipi0Enabled}
+                      onChange={(e) => setMipi0Enabled(e.target.checked)}
+                      className="w-3 h-3"
+                    />
+                  </div>
+                  <div className="text-xs text-center">VC0-VC3</div>
+                </div>
+              )}
+
+              {/* MIPI1 Block - Show in unified and sub */}
+              {(viewMode === 'unified' || viewMode === 'sub') && (
+                <div className="bg-purple-600 text-white p-3 rounded-lg">
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-xs font-semibold">MIPI1</span>
+                    <input
+                      type="checkbox"
+                      checked={mipi1Enabled}
+                      onChange={(e) => setMipi1Enabled(e.target.checked)}
+                      className="w-3 h-3"
+                    />
+                  </div>
+                  <div className="text-xs text-center">VC0-VC3</div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* ISP Column */}
+          <div className="flex flex-col">
+            <div className="text-gray-400 text-sm mb-2 text-center">Internal ISP</div>
+            <div className="bg-green-600 text-white p-3 rounded-lg">
+              <div className="flex items-center gap-1 mb-2 justify-center">
+                <Cpu className="w-4 h-4" />
+                <span className="text-xs font-semibold">ISP</span>
+              </div>
+              <div className="grid grid-cols-2 gap-1 mb-2">
+                {viewMode === 'unified' ? (
+                  <>
+                    <div className="bg-green-700 p-1 rounded text-xs text-center">ISP0</div>
+                    <div className="bg-green-700 p-1 rounded text-xs text-center">ISP1</div>
+                    <div className="bg-green-700 p-1 rounded text-xs text-center">ISP2</div>
+                    <div className="bg-green-700 p-1 rounded text-xs text-center">ISP3</div>
+                  </>
+                ) : viewMode === 'main' ? (
+                  <>
+                    <div className="bg-green-700 p-1 rounded text-xs text-center">ISP0</div>
+                    <div className="bg-green-700 p-1 rounded text-xs text-center">ISP1</div>
+                  </>
+                ) : (
+                  <>
+                    <div className="bg-green-700 p-1 rounded text-xs text-center">ISP2</div>
+                    <div className="bg-green-700 p-1 rounded text-xs text-center">ISP3</div>
+                  </>
+                )}
+              </div>
+              {(viewMode === 'unified' || viewMode === 'main') && (
+                <div className="space-y-1">
+                  <div className="bg-orange-500 text-white p-1 rounded text-xs text-center">D8 IR</div>
+                  <div className="bg-orange-500 text-white p-1 rounded text-xs text-center">D9 IR</div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Camera Mux */}
+          <div className="flex flex-col">
+            <div className="text-gray-400 text-sm mb-2 text-center">Multiplexer</div>
+            <div className="bg-yellow-500 text-black p-3 rounded-lg">
+              <div className="text-xs font-semibold mb-2 text-center">Camera Mux</div>
+              <div className="grid grid-cols-2 gap-1">
+                {Array.from({ length: 8 }, (_, i) => (
+                  <div key={i} className="bg-yellow-400 p-1 rounded text-xs text-center">
+                    CH{i}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* SVDW */}
+          <div className="flex flex-col">
+            <div className="text-gray-400 text-sm mb-2 text-center">SVDW_Wrap</div>
+            <div className="bg-amber-600 text-white p-3 rounded-lg">
+              <div className="text-xs font-semibold mb-2 text-center">SVDW</div>
+              <div className="space-y-1">
+                {['SVDW0', 'SVDW1', 'SVDW2', 'SVDW3'].map((svdw) => (
+                  <div key={svdw} className="text-xs bg-amber-700 p-1 rounded text-center">
+                    {svdw}
+                  </div>
+                ))}
+              </div>
+              <div className="mt-2 text-xs bg-amber-800 p-1 rounded text-center font-semibold">
+                Blender
+              </div>
+            </div>
+          </div>
+
+          {/* VIE Wrap */}
+          <div className="flex flex-col">
+            <div className="text-gray-400 text-sm mb-2 text-center">VIE_Wrap</div>
+            <div className="bg-orange-600 text-white p-3 rounded-lg">
+              <div className="text-xs font-semibold mb-2 text-center">VIE</div>
+              <div className="grid grid-cols-2 gap-1">
+                <div className="text-xs bg-orange-700 p-1 rounded text-center">VWDMA0</div>
+                <div className="text-xs bg-orange-700 p-1 rounded text-center">VWDMA1</div>
+                <div className="text-xs bg-orange-700 p-1 rounded text-center">VIN0</div>
+                <div className="text-xs bg-orange-700 p-1 rounded text-center">VIN1</div>
+              </div>
+            </div>
+          </div>
+
+          {/* MDW */}
+          <div className="flex flex-col">
+            <div className="text-gray-400 text-sm mb-2 text-center">MDW_Wrap</div>
+            <div className="bg-red-600 text-white p-3 rounded-lg">
+              <div className="flex items-center gap-1 mb-2 justify-center">
+                <Monitor className="w-3 h-3" />
+                <span className="text-xs font-semibold">MDW</span>
+              </div>
+              <div className="text-xs bg-red-700 p-1 rounded text-center">
+                MDW0
+              </div>
+            </div>
+          </div>
         </div>
-        <div className="absolute left-80 top-40">
-          <div className="bg-orange-500 text-white p-2 rounded text-xs">IR1</div>
+
+        {/* CIED - Positioned below the grid */}
+        <div className="mt-6 flex justify-center">
+          <div className="bg-cyan-600 text-white p-3 rounded-lg inline-block">
+            <div className="flex items-center gap-2">
+              <AlertCircle className="w-4 h-4" />
+              <span className="text-sm font-semibold">CIED</span>
+            </div>
+            <div className="text-xs mt-1 text-center">Error Detection</div>
+          </div>
         </div>
 
-        {/* Camera Mux */}
-        <ConnectionPoint id="camera-mux" position="right">
-          <div className="absolute left-96 top-16">
-            <div className="bg-yellow-500 text-black p-4 rounded-lg w-40">
-            <div className="font-semibold mb-2">Camera Mux</div>
-            <div className="grid grid-cols-2 gap-1 text-xs">
-              {Array.from({ length: 8 }, (_, i) => (
-                <div key={i} className="bg-yellow-400 p-1 rounded text-center">
-                  CAM CH{i}
-                </div>
-              ))}
-            </div>
-            </div>
-          </div>
-        </ConnectionPoint>
-
-        {/* SVDW */}
-        <ConnectionPoint id="svdw" position="left">
-          <div className="absolute right-32 top-16">
-            <div className="bg-yellow-600 text-white p-4 rounded-lg w-32">
-            <div className="font-semibold mb-2">SVDW</div>
-            <div className="space-y-1">
-              {['Grabber0', 'Grabber1', 'Grabber2', 'Grabber3'].map((grabber, index) => (
-                <div key={grabber} className="text-xs bg-yellow-700 p-1 rounded text-center">
-                  {grabber}
-                </div>
-              ))}
-            </div>
-            <div className="mt-2 text-xs bg-yellow-700 p-1 rounded text-center">
-              Blender
-            </div>
-            </div>
-          </div>
-        </ConnectionPoint>
-
-        {/* Dynamic Connection Lines */}
-        <ConnectionLines connections={connections} containerRef={containerRef} />
 
         {/* Legend */}
-        <div className="absolute bottom-4 left-4 bg-gray-700 p-4 rounded-lg">
-          <h3 className="text-white font-semibold mb-2">Legend</h3>
-          <div className="space-y-1 text-xs text-gray-300">
+        <div className="mt-6 bg-gray-700 p-3 rounded-lg">
+          <h3 className="text-white text-sm font-semibold mb-2">Processing Flow</h3>
+          <div className="flex flex-wrap gap-4 text-xs text-gray-300">
             <div className="flex items-center gap-2">
-              <div className="w-3 h-3 bg-blue-500 rounded"></div>
-              <span>External Device (Selected)</span>
+              <div className="w-6 h-0.5 bg-blue-500"></div>
+              <span>External → MIPI</span>
             </div>
             <div className="flex items-center gap-2">
-              <div className="w-3 h-3 bg-purple-600 rounded"></div>
-              <span>MIPI Interface</span>
+              <div className="w-6 h-0.5 bg-purple-500"></div>
+              <span>MIPI → ISP</span>
             </div>
             <div className="flex items-center gap-2">
-              <div className="w-3 h-3 bg-yellow-500 rounded"></div>
-              <span>Camera Mux</span>
+              <div className="w-6 h-0.5 bg-green-500"></div>
+              <span>ISP → Mux</span>
             </div>
             <div className="flex items-center gap-2">
-              <div className="w-3 h-3 bg-yellow-600 rounded"></div>
-              <span>SVDW (Smart Video Display Window)</span>
+              <div className="w-6 h-0.5 bg-yellow-500"></div>
+              <span>Mux → SVDW</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="w-6 h-0.5 bg-red-500"></div>
+              <span>SVDW → Output</span>
             </div>
           </div>
         </div>

--- a/src/components/Overview/OverviewPage.tsx
+++ b/src/components/Overview/OverviewPage.tsx
@@ -1,11 +1,9 @@
 import React, { useState } from 'react';
-import { Monitor, Cpu, Camera, Wifi, Settings } from 'lucide-react';
+import { Camera } from 'lucide-react';
 import { MainCoreView } from './MainCoreView';
-import { SubCoreView } from './SubCoreView';
 import { ExternalDevicePopup } from './ExternalDevicePopup';
 
 export const OverviewPage: React.FC = () => {
-  const [activeView, setActiveView] = useState<'main' | 'sub'>('main');
   const [selectedDevices, setSelectedDevices] = useState<{
     mipi0: string[];
     mipi1: string[];
@@ -37,52 +35,19 @@ export const OverviewPage: React.FC = () => {
     <div className="flex flex-col h-full bg-gray-900">
       {/* Header */}
       <div className="bg-gray-800 border-b border-gray-700 p-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <Camera className="w-6 h-6 text-primary-500" />
-            <h1 className="text-xl font-bold text-gray-100">Camera Path Overview</h1>
-            <span className="text-sm text-gray-400">TCC807x (Dolphin5)</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              onClick={() => setActiveView('main')}
-              className={`px-4 py-2 rounded-lg transition-colors flex items-center gap-2 ${
-                activeView === 'main' 
-                  ? 'bg-primary-600 text-white' 
-                  : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
-              }`}
-            >
-              <Monitor className="w-4 h-4" />
-              Main Core View
-            </button>
-            <button
-              onClick={() => setActiveView('sub')}
-              className={`px-4 py-2 rounded-lg transition-colors flex items-center gap-2 ${
-                activeView === 'sub' 
-                  ? 'bg-primary-600 text-white' 
-                  : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
-              }`}
-            >
-              <Cpu className="w-4 h-4" />
-              Sub Core View
-            </button>
-          </div>
+        <div className="flex items-center gap-4">
+          <Camera className="w-6 h-6 text-primary-500" />
+          <h1 className="text-xl font-bold text-gray-100">Camera Path Overview</h1>
+          <span className="text-sm text-gray-400">TCC807x (Dolphin5)</span>
         </div>
       </div>
 
       {/* Content */}
       <div className="flex-1 overflow-auto p-6">
-        {activeView === 'main' ? (
-          <MainCoreView 
-            selectedDevices={selectedDevices}
-            onDeviceClick={openDevicePopup}
-          />
-        ) : (
-          <SubCoreView 
-            selectedDevices={selectedDevices}
-            onDeviceClick={openDevicePopup}
-          />
-        )}
+        <MainCoreView
+          selectedDevices={selectedDevices}
+          onDeviceClick={openDevicePopup}
+        />
       </div>
 
       {/* External Device Popup */}

--- a/src/components/Overview/SubCoreView.tsx
+++ b/src/components/Overview/SubCoreView.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { Camera, Wifi, Settings, ChevronDown } from 'lucide-react';
-import { ConnectionLines, ConnectionPoint } from './ConnectionLines';
+import { Camera, Wifi, Settings, ChevronDown, Cpu, Box, Monitor, AlertCircle } from 'lucide-react';
 
 interface SubCoreViewProps {
   selectedDevices: {
@@ -17,16 +16,15 @@ export const SubCoreView: React.FC<SubCoreViewProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const [mipi0Enabled, setMipi0Enabled] = useState(false);
   const [mipi1Enabled, setMipi1Enabled] = useState(true);
+  const [ispSelections, setIspSelections] = useState({
+    isp0: 'ISP0',
+    isp1: 'ISP1',
+    isp2: 'ISP2',
+    isp3: 'ISP3'
+  });
 
   const deviceColors = ['bg-gray-400', 'bg-gray-400', 'bg-gray-400', 'bg-gray-400'];
 
-  // 연결선 정의
-  const connections = [
-    { from: 'external-devices-mipi1', to: 'mipi1', color: '#9ca3af', strokeWidth: 3 },
-    { from: 'mipi1', to: 'camera-mux-sub', color: '#8b5cf6', strokeWidth: 3 },
-    { from: 'camera-mux-sub', to: 'output-modules', color: '#eab308', strokeWidth: 3 },
-    { from: 'camera-mux-sub', to: 'cied', color: '#16a34a', strokeWidth: 2 },
-  ];
 
   return (
     <div className="w-full h-full">
@@ -37,159 +35,191 @@ export const SubCoreView: React.FC<SubCoreViewProps> = ({
       </div>
 
       {/* Diagram Container */}
-      <div ref={containerRef} className="relative w-full h-full min-h-[600px] bg-gray-800 rounded-lg p-8">
+      <div ref={containerRef} className="w-full bg-gray-800 rounded-lg p-6">
         
-        {/* External Devices - MIPI1 */}
-        <ConnectionPoint id="external-devices-mipi1" position="right">
-          <div className="absolute left-8 top-16">
-            <div 
-              className="bg-blue-600 text-white p-4 rounded-lg cursor-pointer hover:bg-blue-700 transition-colors"
-              onClick={() => onDeviceClick('mipi1')}
-            >
-            <div className="flex items-center gap-2 mb-2">
-              <Camera className="w-5 h-5" />
-              <span className="font-semibold">External Devices</span>
-            </div>
-            <div className="grid grid-cols-2 gap-2">
-              {deviceColors.map((color, index) => (
-                <div 
-                  key={index}
-                  className={`w-8 h-8 rounded ${color} ${
-                    selectedDevices.mipi1.includes(`device${index}`) 
-                      ? 'ring-2 ring-white' 
-                      : 'opacity-50'
-                  }`}
-                />
-              ))}
-            </div>
-            </div>
-          </div>
-        </ConnectionPoint>
+        {/* Main Grid Layout */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7 gap-4 relative">
 
-        {/* MIPI1 Block */}
-        <ConnectionPoint id="mipi1" position="right">
-          <div className="absolute left-48 top-16">
-            <div className="bg-purple-600 text-white p-4 rounded-lg w-32">
-            <div className="flex items-center justify-between mb-2">
-              <span className="font-semibold">MIPI1</span>
-              <input
-                type="checkbox"
-                checked={mipi1Enabled}
-                onChange={(e) => setMipi1Enabled(e.target.checked)}
-                className="w-4 h-4"
-              />
-            </div>
-            <div className="text-xs mb-2">I2C13</div>
-            <div className="space-y-1">
-              {Array.from({ length: 4 }, (_, i) => (
-                <div key={i} className="flex items-center gap-2">
-                  <div className="w-2 h-2 bg-white rounded-full"></div>
-                  <span className="text-xs">Bypass</span>
+          {/* External Devices Column */}
+          <div className="flex flex-col">
+            <div className="text-gray-400 text-sm mb-2 text-center">External Devices</div>
+            <div className="space-y-3">
+              {/* External Device 1 */}
+              <div
+                className="bg-blue-600 text-white p-3 rounded-lg cursor-pointer hover:bg-blue-700 transition-colors"
+                onClick={() => onDeviceClick('mipi0')}
+              >
+                <div className="flex items-center gap-2 justify-center">
+                  <Camera className="w-4 h-4" />
+                  <span className="text-xs font-semibold">Device 1</span>
                 </div>
-              ))}
-            </div>
+              </div>
+
+              {/* External Device 2 */}
+              <div
+                className="bg-blue-600 text-white p-3 rounded-lg cursor-pointer hover:bg-blue-700 transition-colors"
+                onClick={() => onDeviceClick('mipi1')}
+              >
+                <div className="flex items-center gap-2 justify-center">
+                  <Camera className="w-4 h-4" />
+                  <span className="text-xs font-semibold">Device 2</span>
+                </div>
+              </div>
             </div>
           </div>
-        </ConnectionPoint>
 
-        {/* Camera Mux */}
-        <ConnectionPoint id="camera-mux-sub" position="right">
-          <div className="absolute left-96 top-16">
-            <div className="bg-yellow-500 text-black p-4 rounded-lg w-40">
-              <div className="font-semibold mb-2">Camera Mux</div>
-              <div className="grid grid-cols-2 gap-1 text-xs">
+          {/* MIPI Column */}
+          <div className="flex flex-col">
+            <div className="text-gray-400 text-sm mb-2 text-center">MIPI CSI</div>
+            <div className="space-y-3">
+              {/* MIPI0 Block */}
+              <div className="bg-purple-600 text-white p-3 rounded-lg">
+                <div className="flex items-center justify-between mb-1">
+                  <span className="text-xs font-semibold">MIPI0</span>
+                  <input
+                    type="checkbox"
+                    checked={mipi0Enabled}
+                    onChange={(e) => setMipi0Enabled(e.target.checked)}
+                    className="w-3 h-3"
+                  />
+                </div>
+                <div className="text-xs text-center">VC0-VC3</div>
+              </div>
+
+              {/* MIPI1 Block */}
+              <div className="bg-purple-600 text-white p-3 rounded-lg">
+                <div className="flex items-center justify-between mb-1">
+                  <span className="text-xs font-semibold">MIPI1</span>
+                  <input
+                    type="checkbox"
+                    checked={mipi1Enabled}
+                    onChange={(e) => setMipi1Enabled(e.target.checked)}
+                    className="w-3 h-3"
+                  />
+                </div>
+                <div className="text-xs text-center">VC0-VC3</div>
+              </div>
+            </div>
+          </div>
+
+          {/* ISP Column */}
+          <div className="flex flex-col">
+            <div className="text-gray-400 text-sm mb-2 text-center">Internal ISP</div>
+            <div className="bg-green-600 text-white p-3 rounded-lg">
+              <div className="flex items-center gap-1 mb-2 justify-center">
+                <Cpu className="w-4 h-4" />
+                <span className="text-xs font-semibold">ISP</span>
+              </div>
+              <div className="grid grid-cols-2 gap-1 mb-2">
+                <div className="bg-green-700 p-1 rounded text-xs text-center">ISP0</div>
+                <div className="bg-green-700 p-1 rounded text-xs text-center">ISP1</div>
+                <div className="bg-green-700 p-1 rounded text-xs text-center">ISP2</div>
+                <div className="bg-green-700 p-1 rounded text-xs text-center">ISP3</div>
+              </div>
+              <div className="space-y-1">
+                <div className="bg-orange-500 text-white p-1 rounded text-xs text-center">D8 IR</div>
+                <div className="bg-orange-500 text-white p-1 rounded text-xs text-center">D9 IR</div>
+              </div>
+            </div>
+          </div>
+
+          {/* Camera Mux */}
+          <div className="flex flex-col">
+            <div className="text-gray-400 text-sm mb-2 text-center">Multiplexer</div>
+            <div className="bg-yellow-500 text-black p-3 rounded-lg">
+              <div className="text-xs font-semibold mb-2 text-center">Camera Mux</div>
+              <div className="grid grid-cols-2 gap-1">
                 {Array.from({ length: 8 }, (_, i) => (
-                  <div key={i} className={`p-1 rounded text-center ${
-                    i >= 4 ? 'bg-yellow-400' : 'bg-gray-300'
-                  }`}>
-                    CAM CH{i}
+                  <div key={i} className="bg-yellow-400 p-1 rounded text-xs text-center">
+                    CH{i}
                   </div>
                 ))}
               </div>
             </div>
           </div>
-        </ConnectionPoint>
 
-        {/* Output Modules */}
-        <ConnectionPoint id="output-modules" position="left">
-          <div className="absolute right-32 top-16">
-            <div className="space-y-4">
-            {/* VWDMA0 */}
-            <div className="bg-green-500 text-white p-3 rounded-lg w-24">
-              <div className="font-semibold text-sm mb-1">VWDMA0</div>
-              <div className="text-xs">IR</div>
-            </div>
-
-            {/* VWDMA1 */}
-            <div className="bg-green-500 text-white p-3 rounded-lg w-24">
-              <div className="font-semibold text-sm mb-1">VWDMA1</div>
-              <div className="text-xs">IR</div>
-            </div>
-
-            {/* VIN0 */}
-            <div className="bg-blue-500 text-white p-3 rounded-lg w-24">
-              <div className="font-semibold text-sm">VIN0</div>
-            </div>
-
-            {/* VIN1 */}
-            <div className="bg-blue-500 text-white p-3 rounded-lg w-24">
-              <div className="font-semibold text-sm">VIN1</div>
-            </div>
-
-            {/* MDW */}
-            <div className="bg-purple-500 text-white p-3 rounded-lg w-24">
-              <div className="font-semibold text-sm">MDW</div>
-            </div>
+          {/* SVDW */}
+          <div className="flex flex-col">
+            <div className="text-gray-400 text-sm mb-2 text-center">SVDW_Wrap</div>
+            <div className="bg-amber-600 text-white p-3 rounded-lg">
+              <div className="text-xs font-semibold mb-2 text-center">SVDW</div>
+              <div className="space-y-1">
+                {['SVDW0', 'SVDW1', 'SVDW2', 'SVDW3'].map((svdw) => (
+                  <div key={svdw} className="text-xs bg-amber-700 p-1 rounded text-center">
+                    {svdw}
+                  </div>
+                ))}
+              </div>
+              <div className="mt-2 text-xs bg-amber-800 p-1 rounded text-center font-semibold">
+                Blender
+              </div>
             </div>
           </div>
-        </ConnectionPoint>
 
-        {/* CIED */}
-        <ConnectionPoint id="cied" position="left">
-          <div className="absolute right-32 bottom-16">
-            <div className="bg-green-600 text-white p-4 rounded-lg">
-            <div className="font-semibold mb-2">CIED</div>
-            <div className="grid grid-cols-5 gap-1">
-              {Array.from({ length: 10 }, (_, i) => (
-                <div key={i} className="bg-green-700 w-6 h-6 rounded text-xs flex items-center justify-center">
-                  {i}
-                </div>
-              ))}
-            </div>
+          {/* VIE Wrap */}
+          <div className="flex flex-col">
+            <div className="text-gray-400 text-sm mb-2 text-center">VIE_Wrap</div>
+            <div className="bg-orange-600 text-white p-3 rounded-lg">
+              <div className="text-xs font-semibold mb-2 text-center">VIE</div>
+              <div className="grid grid-cols-2 gap-1">
+                <div className="text-xs bg-orange-700 p-1 rounded text-center">VWDMA0</div>
+                <div className="text-xs bg-orange-700 p-1 rounded text-center">VWDMA1</div>
+                <div className="text-xs bg-orange-700 p-1 rounded text-center">VIN0</div>
+                <div className="text-xs bg-orange-700 p-1 rounded text-center">VIN1</div>
+              </div>
             </div>
           </div>
-        </ConnectionPoint>
 
-        {/* Dynamic Connection Lines */}
-        <ConnectionLines connections={connections} containerRef={containerRef} />
+          {/* MDW */}
+          <div className="flex flex-col">
+            <div className="text-gray-400 text-sm mb-2 text-center">MDW_Wrap</div>
+            <div className="bg-red-600 text-white p-3 rounded-lg">
+              <div className="flex items-center gap-1 mb-2 justify-center">
+                <Monitor className="w-3 h-3" />
+                <span className="text-xs font-semibold">MDW</span>
+              </div>
+              <div className="text-xs bg-red-700 p-1 rounded text-center">
+                MDW0
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* CIED - Positioned below the grid */}
+        <div className="mt-6 flex justify-center">
+          <div className="bg-cyan-600 text-white p-3 rounded-lg inline-block">
+            <div className="flex items-center gap-2">
+              <AlertCircle className="w-4 h-4" />
+              <span className="text-sm font-semibold">CIED</span>
+            </div>
+            <div className="text-xs mt-1 text-center">Error Detection</div>
+          </div>
+        </div>
+
 
         {/* Legend */}
-        <div className="absolute bottom-4 left-4 bg-gray-700 p-4 rounded-lg">
-          <h3 className="text-white font-semibold mb-2">Legend</h3>
-          <div className="space-y-1 text-xs text-gray-300">
+        <div className="mt-6 bg-gray-700 p-3 rounded-lg">
+          <h3 className="text-white text-sm font-semibold mb-2">Processing Flow</h3>
+          <div className="flex flex-wrap gap-4 text-xs text-gray-300">
             <div className="flex items-center gap-2">
-              <div className="w-3 h-3 bg-gray-400 rounded"></div>
-              <span>External Device (Unselected)</span>
+              <div className="w-6 h-0.5 bg-blue-500"></div>
+              <span>External → MIPI</span>
             </div>
             <div className="flex items-center gap-2">
-              <div className="w-3 h-3 bg-purple-600 rounded"></div>
-              <span>MIPI Interface</span>
+              <div className="w-6 h-0.5 bg-purple-500"></div>
+              <span>MIPI → ISP</span>
             </div>
             <div className="flex items-center gap-2">
-              <div className="w-3 h-3 bg-yellow-500 rounded"></div>
-              <span>Camera Mux</span>
+              <div className="w-6 h-0.5 bg-green-500"></div>
+              <span>ISP → Mux</span>
             </div>
             <div className="flex items-center gap-2">
-              <div className="w-3 h-3 bg-green-500 rounded"></div>
-              <span>VWDMA (Video Write DMA)</span>
+              <div className="w-6 h-0.5 bg-yellow-500"></div>
+              <span>Mux → SVDW</span>
             </div>
             <div className="flex items-center gap-2">
-              <div className="w-3 h-3 bg-blue-500 rounded"></div>
-              <span>VIN (Video Input)</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="w-3 h-3 bg-green-600 rounded"></div>
-              <span>CIED (Camera Input Event Detector)</span>
+              <div className="w-6 h-0.5 bg-red-500"></div>
+              <span>SVDW → Output</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
- Convert absolute positioning to responsive grid layout (1-7 columns based on screen size)
- Remove bezier curves in favor of straight line connections
- Add ViewMode support (unified/main/sub) with dynamic component visibility
- Remove Main/Sub Core toggle buttons from OverviewPage
- Update MainCoreView to show different components based on selected view mode
- Clean up SubCoreView with matching grid layout improvements